### PR TITLE
Fix Etherpad running in Development mode

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,6 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 Environment="PATH=__ENV_PATH__"
+Environment=NODE_ENV=production
 ExecStart=__FINALPATH__/bin/safeRun.sh /var/log/__APP__/etherpad.log
 Restart=always
 


### PR DESCRIPTION
## Problem
- *Etherpad log says "Etherpad is running in Development mode.  This mode is slower for users and less secure than production mode.  You should set the NODE_ENV environment variable to production by using: export NODE_ENV=production"*

## Solution
- *Use NODE_ENV=production
Some information [here](https://gist.github.com/antishok/bfc643079f98148e38d0260134c6dea8).*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20etherpad_dev_mode%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20etherpad_dev_mode%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.