### PR TITLE
Do not fail on modules upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -163,7 +163,7 @@ do
 	echo "Update $node_module"
 	(cd "$final_path/node_modules/$node_module"
 	npm cache clean
-	ynh_exec_warn_less npm update)
+	ynh_exec_warn_less npm update || true)
 done <<< "$(ls -1 "$final_path/node_modules")"
 
 #=================================================


### PR DESCRIPTION
## Problem
- *Sometimes, the upgrade fails because of an error with a module.*

## Solution
- *We don't really care about the upgrade of the module. So do not fail an upgrade just because of that.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : Josué
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20donotfail_modules_upgrade%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20donotfail_modules_upgrade%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.