### PR TITLE
Upgrade to 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 Etherpad is a highly customizable Open Source online editor providing collaborative editing in really real-time.  
 This package will install the same plugins than [Framapad](https://framapad.org/).
 
-**Shipped version:** 1.6.5
+**Shipped version:** 1.7.0
 
 ## Screenshots
 
@@ -29,7 +29,7 @@ Or, you can find a config file for etherpad at this path `/var/www/etherpad_mypa
 
 ## Documentation
 
- * Official documentation: http://etherpad.org/doc/v1.6.5
+ * Official documentation: http://etherpad.org/doc/v1.7.0
  * YunoHost documentation: There no other documentations, feel free to contribute.
 
 ## YunoHost specific features

--- a/README_fr.md
+++ b/README_fr.md
@@ -12,7 +12,7 @@ Si vous n'avez pas YunoHost, merci de regarder [ici](https://yunohost.org/#/inst
 Etherpad est un éditeur en ligne Open Source hautement personnalisable qui permet l'édition collaborative en temps réel.  
 Ce paquet installera les mêmes plugins que [Framapad](https://framapad.org/).
 
-**Version embarquée:** 1.6.5
+**Version embarquée:** 1.7.0
 
 ## Captures d'écran
 
@@ -29,7 +29,7 @@ Ou, vous pouvez trouver un fichier de configuration pour etherpad à `/var/www/e
 
 ## Documentation
 
- * Documentation officielle: http://etherpad.org/doc/v1.6.5
+ * Documentation officielle: http://etherpad.org/doc/v1.7.0
  * Documentation YunoHost: Il n'y a pas d'autre documentation, n'hésitez pas à contribuer.
 
 ## Fonctionnalités spécifiques à YunoHost

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/ether/etherpad-lite/archive/1.6.5.tar.gz
-SOURCE_SUM=e0c5fac06a4ec37cfba66f4514bc27ef
+SOURCE_URL=https://github.com/ether/etherpad-lite/archive/1.7.0.tar.gz
+SOURCE_SUM=71fe286cf3e8dc45b0b5963de54f2ff6
 SOURCE_SUM_PRG=md5sum
 ARCH_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 		"en": "Framapad clone, a online editor providing collaborative editing in real-time.",
 		"fr": "Clone de Framapad, un éditeur en ligne fournissant l'édition collaborative en temps réel."
 	},
-	"version": "1.6.5~ynh4",
+	"version": "1.7.0~ynh1",
 	"url": "https://framapad.org",
 	"license": "Apache-2.0",
 	"maintainer": {

--- a/scripts/_variables
+++ b/scripts/_variables
@@ -7,8 +7,8 @@ abiword_app_depencencies="abiword"
 libreoffice_app_dependencies="unoconv libreoffice-writer"
 
 # Version of nodejs
-nodejs_version=4
+nodejs_version=6
 
 # Version of mypads
 # This variable is mostly used to force an upgrade of the package in case of new versions of mypads.
-mypads_version=1.4.6
+mypads_version=1.6.2

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -158,13 +158,13 @@ npm cache clean
 ynh_exec_warn_less npm update)
 
 # Then update the additionnal modules
+(cd "$final_path"
+npm cache clean
 while read node_module
 do
 	echo "Update $node_module"
-	(cd "$final_path/node_modules/$node_module"
-	npm cache clean
-	ynh_exec_warn_less npm update || true)
-done <<< "$(ls -1 "$final_path/node_modules")"
+        ynh_exec_warn_less npm install --upgrade $node_module || true
+done <<< "$(ls -1 "$final_path/node_modules" | grep "^ep_")")
 
 #=================================================
 # SPECIFIC UPGRADE


### PR DESCRIPTION
## Problem
- *Etherpad fails to start because of a syntax error (see https://forum.yunohost.org/t/etherpad-mypads-502-bad-gateway-migration-yunohost-2-7-3-1/5468/2)*
- *The update of the npm modules is not fully functional.*
- *Etherpad and mypads are not up to date.*
- Fix https://github.com/YunoHost-Apps/etherpad_mypads_ynh/issues/36, https://github.com/YunoHost-Apps/etherpad_mypads_ynh/issues/39, https://github.com/YunoHost-Apps/etherpad_mypads_ynh/issues/47 and PR https://github.com/YunoHost-Apps/etherpad_mypads_ynh/pull/45

## Solution
- *Upgrade Etherpad to 1.7.0*
- *Upgrade Mypads module to 1.6.2*
- *Fix the way modules are updated*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : frju365
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20update17%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20update17%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.