### PR TITLE
Set permissions during the restore script

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -126,6 +126,13 @@ npm cache clean
 npm install forever -g >> $install_log 2>&1
 
 #=================================================
+# SECURING FILES AND DIRECTORIES
+#=================================================
+
+# Set files ownership to etherpad
+chown -R $app: $final_path
+
+#=================================================
 # ENABLE SERVICE IN ADMIN PANEL
 #=================================================
 


### PR DESCRIPTION
## Problem
- *Permissions are not set back during the restoration, https://github.com/YunoHost-Apps/etherpad_mypads_ynh/issues/52#issuecomment-423254171*

## Solution
- *Set the permissions in the restore script.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Josué
- [x] **Approval (LGTM)** :  Anmol
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20perms_restore%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20perms_restore%20(Official)/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
