### PR TITLE
[enh] Allow to include a pad in an other page

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,7 +7,7 @@ location __PATH__/ {
 	proxy_pass             http://127.0.0.1:__PORT__/;
 	proxy_set_header       Host $host;
 	proxy_buffering off;
-	more_set_headers X-Frame-Options "ALLOWALL";
+	more_set_headers "X-Frame-Options : ALLOWALL";
 
 	# Include SSOWAT user panel.
 	include conf.d/yunohost_panel.conf.inc;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,7 +7,7 @@ location __PATH__/ {
 	proxy_pass             http://127.0.0.1:__PORT__/;
 	proxy_set_header       Host $host;
 	proxy_buffering off;
-	add_header X-Frame-Options "ALLOWALL";
+	more_set_headers X-Frame-Options "ALLOWALL";
 
 	# Include SSOWAT user panel.
 	include conf.d/yunohost_panel.conf.inc;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -7,6 +7,7 @@ location __PATH__/ {
 	proxy_pass             http://127.0.0.1:__PORT__/;
 	proxy_set_header       Host $host;
 	proxy_buffering off;
+	add_header X-Frame-Options "ALLOWALL";
 
 	# Include SSOWAT user panel.
 	include conf.d/yunohost_panel.conf.inc;


### PR DESCRIPTION
## Problem
It's not possible to include a pad in a frame. The Libreto package need it.

## Solution
Change the header

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20allow-frame%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/etherpad_mypads_ynh%20allow-frame%20(Official)/)
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.