### PR TITLE
Show a link to mypads only if installed

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -369,7 +369,7 @@ fi
 # SOME HACKS
 #=================================================
 
-if [ "$upgrade_type" == "UPGRADE_APP" ]
+if [ "$upgrade_type" == "UPGRADE_APP" ] && [ $mypads -eq 1 ]
 then
 	# Find the /div just after the field to open a pad
 	mod_line=$(grep -nA5 "index.createOpenPad" $final_path/src/templates/index.html | grep "</div>" | cut -d '-' -f 1)


### PR DESCRIPTION
## Problem
- *The link to mypads is added even if mypads isn't installed.*

## Solution
- *Fix #90*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** :  Kay0u
- [x] **Approval (LGTM)** : JimboJoe
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/etherpad_mypads_ynh%20PR91/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/etherpad_mypads_ynh%20PR91/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.