### PR TITLE
Use instance name instead of app name in config

### DIFF
--- a/scripts/config
+++ b/scripts/config
@@ -15,7 +15,7 @@ source _variables
 # RETRIEVE ARGUMENTS
 #=================================================
 
-app=${YNH_APP_INSTANCE_NAME:-$YNH_APP_ID}
+app=$YNH_APP_INSTANCE_NAME
 
 final_path=$(ynh_app_setting_get $app final_path)
 


### PR DESCRIPTION
## Problem
- #92 

## Solution
- *Simply use `app=$YNH_APP_INSTANCE_NAME`*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** :  
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/etherpad_mypads_ynh%20PR93/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/etherpad_mypads_ynh%20PR93/)  
When the PR is marked as ready to merge, we have to wait for 3 days before really merging it.
