### PR TITLE
Fix plugin issue

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -223,6 +223,8 @@ ynh_script_progression --message="Upgrading Etherpad npm modules..." --weight=60
 chown -R $app: $final_path
 (cd "$final_path/src"
 ynh_exec_warn_less npm cache clean --force
+# Remove package-lock.json to prevent any shit during npm update...
+ynh_secure_remove --file="$final_path/src/package-lock.json"
 ynh_exec_warn_less ynh_exec_as $app PATH="$nodejs_path:$PATH" "$nodejs_path/npm" update)
 
 # Then update the additionnal modules


### PR DESCRIPTION
## Problem
- *After upgrade to 1.8.0, adding or removing a plugin fails with a strange error*

## Solution
- *It appears that the file package-lock.json does often break the upgrade of npm...*
- *Remove the file before the upgrade.*
- *Fix #90*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** :  Kay0u
- [ ] **Approval (LGTM)** : 
*Code review and approval have to be from a member of @YunoHost-Apps/apps-group*
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/etherpad_mypads_ynh%20PR94/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/etherpad_mypads_ynh%20PR94/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.