### PR TITLE
Recommended proxy_http version for keepalive connections

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,6 +12,11 @@ location __PATH__/ {
 	proxy_buffering off;
 	more_set_headers "X-Frame-Options : ALLOWALL";
 
+        # Recommended proxy_http version for keepalive connections
+        # https://github.com/ether/etherpad-lite/wiki/How-to-put-Etherpad-Lite-behind-a-reverse-Proxy#nginx
+        proxy_http_version 1.1;
+
+
 	# Include SSOWAT user panel.
 	include conf.d/yunohost_panel.conf.inc;
 }


### PR DESCRIPTION
Etherpad improvment

https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version