### PR TITLE
Remove automatic logut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## [1.8.13~ynh2]() - 2021-05-14
+
+#### Disabled
+* [ep_automatic_logut plugin](https://github.com/YunoHost-Apps/etherpad_mypads_ynh/pull/140/files)
+
+
 ## [1.8.13~ynh1]() - 2021-03-23
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ You can also find a configuration file for Etherpad at this path `/var/www/ether
 
   * [ep_align](https://www.npmjs.com/package/ep_align) - *Add Left/Center/Right/Justify to lines of text in a pad*
   * [ep_author_hover](https://www.npmjs.com/package/ep_author_hover) - *Adds author names to span titles*
-  * [ep_automatic_logut](https://www.npmjs.com/package/ep_automatic_logut) - *Automatically disconnects user after some period of time (Prevent server overload)*
   * [ep_comments_page](https://www.npmjs.com/package/ep_comments_page) - *Adds comments on sidebar and link it to the text.*
   * [ep_countable](https://www.npmjs.com/package/ep_countable) - *Adds paragraphs, words and characters count*
   * [ep_delete_empty_pads](https://www.npmjs.com/package/ep_delete_empty_pads) - *Delete pads which were never edited*

--- a/README_fr.md
+++ b/README_fr.md
@@ -53,7 +53,6 @@ Vous pouvez accéder à deux panneaux d'administration différents, pour Etherpa
 
   * [ep_align](https://www.npmjs.com/package/ep_align) - *Ajoute Gauche/Centre/Droite/Justifier à des lignes de texte dans un pad*
   * [ep_author_hover](https://www.npmjs.com/package/ep_author_hover) - *Ajoute des noms d'auteurs*
-  * [ep_automatic_logut](https://www.npmjs.com/package/ep_automatic_logut) - *Déconnecte automatiquement l'utilisateur après une certaine période de temps (Prévient la surcharge du serveur)*
   * [ep_comments_page](https://www.npmjs.com/package/ep_comments_page) - *Ajoute des commentaires sur la sidebar et le lie au texte.*
   * [ep_countable](https://www.npmjs.com/package/ep_countable) - *Ajoute l'afficher le nombre de paragraphes, de mots et de caractères*
   * [ep_delete_empty_pads](https://www.npmjs.com/package/ep_delete_empty_pads) - *Supprimer les pads qui n'ont jamais été édités*

--- a/check_process
+++ b/check_process
@@ -18,7 +18,6 @@
         main.pad_configuration.pad_config_chatandusers=1|0
         main.pad_configuration.pad_config_alwaysshowchat=1|0
         main.pad_configuration.pad_config_show_markdown=1|0
-        main.pad_configuration.pad_config_automatic_logout=0|1
         main.mypads_configuration.mypads=0|1
         main.mypads_configuration.useldap=0|1
         main.overwrite_files.overwrite_settings=0|1

--- a/conf/settings.json
+++ b/conf/settings.json
@@ -204,9 +204,6 @@
   },
 
   // Plugins config
-		// ep_automatic_logut
-		"automatic_logut_mins_show" : true,	// Show logout time selector
-		"automatic_logut_url" : "../../",	// Redirection URL address
 
 		// ep_markdown
 		"ep_markdown_default": false,	// Setting as default

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -41,11 +41,6 @@ name = "Etherpad configuration"
         ask = "Show markdown syntax?"
         type = "boolean"
         default = false
-
-        [main.pad_configuration.pad_config_automatic_logout]
-        ask = "Automatic logout"
-        type = "boolean"
-        default = true
         
 
     [main.mypads_configuration]

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
 		"email": "maniackc_dev@crudelis.fr"
 	}],
 	"requirements": {
-		"yunohost": ">= 4.1.7"
+		"yunohost": ">= 4.2.4"
 	},
 	"multi_instance": true,
 	"services": [

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
 		"email": "maniackc_dev@crudelis.fr"
 	}],
 	"requirements": {
-		"yunohost": ">= 4.2.4"
+		"yunohost": ">= 4.1.7"
 	},
 	"multi_instance": true,
 	"services": [

--- a/scripts/_variables
+++ b/scripts/_variables
@@ -16,7 +16,6 @@ mypads_version=1.7.20
 # Plugin versions
 ep_align_version=0.3.34
 ep_author_hover_version=0.3.19
-ep_automatic_logut_version=1.0.8
 ep_comments_page_version=0.1.60
 ep_countable_version=0.0.11
 ep_delete_empty_pads_version=0.0.7

--- a/scripts/config
+++ b/scripts/config
@@ -67,17 +67,6 @@ pad_config_alwaysshowchat="${YNH_CONFIG_MAIN_PAD_CONFIGURATION_PAD_CONFIG_ALWAYS
 old_pad_config_show_markdown="$(get_config_value ep_markdown_default)"
 pad_config_show_markdown="${YNH_CONFIG_MAIN_PAD_CONFIGURATION_PAD_CONFIG_SHOW_MARKDOWN:-$old_pad_config_show_markdown}"
 
-# Enable/disable ep_automatic_logut
-if grep -q "//.*\"automatic_logut_" $config_file
-then
-    # Disable
-	old_pad_config_automatic_logout=0
-else
-    # Enable
-	old_pad_config_automatic_logout=1
-fi
-pad_config_automatic_logout="${YNH_CONFIG_MAIN_PAD_CONFIGURATION_PAD_CONFIG_AUTOMATIC_LOGOUT:-$old_pad_config_automatic_logout}"
-
 # MyPads
 if [ -d $final_path/node_modules/ep_mypads ]
 then
@@ -131,7 +120,6 @@ show_config() {
 	ynh_return "YNH_CONFIG_MAIN_PAD_CONFIGURATION_PAD_CONFIG_CHATANDUSERS=$pad_config_chatandusers"
 	ynh_return "YNH_CONFIG_MAIN_PAD_CONFIGURATION_PAD_CONFIG_ALWAYSSHOWCHAT=$pad_config_alwaysshowchat"
 	ynh_return "YNH_CONFIG_MAIN_PAD_CONFIGURATION_PAD_CONFIG_SHOW_MARKDOWN=$pad_config_show_markdown"
-	ynh_return "YNH_CONFIG_MAIN_PAD_CONFIGURATION_PAD_CONFIG_AUTOMATIC_LOGOUT=$pad_config_automatic_logout"
 	ynh_return "YNH_CONFIG_MAIN_MYPADS_CONFIGURATION_MYPADS=$mypads"
 	ynh_return "YNH_CONFIG_MAIN_MYPADS_CONFIGURATION_USELDAP=$useldap"
 	ynh_return "YNH_CONFIG_MAIN_OVERWRITE_FILES_OVERWRITE_SETTINGS=$overwrite_settings"
@@ -192,25 +180,6 @@ apply_config() {
 		ynh_app_setting_set --app=$app --key=pad_config_show_markdown --value="$pad_config_show_markdown"
 		restart_etherpad=1
 	fi
-
-    # Plugin option ep_automatic_logut
-    if [ "$pad_config_automatic_logout" != "$old_pad_config_automatic_logout" ]
-    then
-        ynh_use_nodejs
-        #pushd "$final_path/src"
-        #ynh_secure_remove --file="$final_path/src/package-lock.json" #added to fix saveError ENOENT: no such file or directory
-        if [ "$pad_config_automatic_logout" = "0" ]
-        then
-            ynh_replace_string --match_string="^\(.*\"automatic_logut.*$\)" --replace_string="\/\/\1" --target_file="$config_file"
-            ynh_exec_as $app env "$ynh_node_load_PATH" npm uninstall ep_automatic_logut
-        else
-            ynh_replace_string --match_string="^\/\/\(.*\"automatic_logut.*$\)" --replace_string="\1" --target_file="$config_file"
-            ynh_exec_as $app env "$ynh_node_load_PATH" npm install ep_automatic_logut@${ep_automatic_logut_version}
-        fi
-        popd
-        chown -R $app: $final_path/node_modules
-        restart_etherpad=1
-    fi
 
 	# Export
 	if [ "$export" != "$old_export" ]

--- a/scripts/config
+++ b/scripts/config
@@ -8,7 +8,6 @@
 
 # Load common variables for all scripts.
 source _variables
-
 source _common.sh
 source /usr/share/yunohost/helpers
 

--- a/scripts/install
+++ b/scripts/install
@@ -220,7 +220,7 @@ chmod 600 $final_path/credentials.json
 ynh_script_progression --message="Configuring a systemd service..." --weight=4
 
 # Create a dedicated systemd config
-ynh_add_systemd_config --others_var="ynh_node_load_PATH"
+ynh_add_systemd_config
 
 #=================================================
 # ADVERTISE SERVICE IN ADMIN PANEL
@@ -278,10 +278,7 @@ then
 	ynh_replace_string --match_string="^ *\"FOOTER\": .*2.0" --replace_string="& | <a href='../admin'>Etherpad admin</a>" --target_file=$final_path/node_modules/ep_mypads/static/l10n/en.json
 	ynh_replace_string --match_string="^ *\"FOOTER\": .*2.0" --replace_string="& | <a href='../admin'>Etherpad admin</a>" --target_file=$final_path/node_modules/ep_mypads/static/l10n/fr.json
 
-	## Find the /div just after the field to open a pad
-	#mod_line=$(grep -nA5 "index.createOpenPad" $final_path/src/templates/index.html | grep "</div>" | cut -d '-' -f 1)
-	## In order to add a link to MyPads plugin.
-	#sed -i "$mod_line s@div>@&\n\t<center><br><font size="5"><a href="./mypads/">MyPads</a></font></center>@" $final_path/src/templates/index.html
+	# Find the /div just after the field to open a pad in order to add a link to MyPads plugin.
 	sed -i '157i<center><br><font size="4"><a href="./mypads/" style="text-decoration: none; color: #555">MyPads</a></font></center>' $final_path/src/templates/index.html
 fi
 

--- a/scripts/install
+++ b/scripts/install
@@ -238,8 +238,6 @@ pushd "$final_path"
 ynh_npm install ep_align@${ep_align_version} >> $install_log 2>&1
 # Framapad - Adds author names to span titles
 ynh_npm install ep_author_hover@${ep_author_hover_version} >> $install_log 2>&1
-# Automatically disconnects user after some period of time (Prevent server overload)
-ynh_npm install ep_automatic_logut@${ep_automatic_logut_version} >> $install_log 2>&1
 # Framapad - Adds comments on sidebar and link it to the text.
 ynh_npm install ep_comments_page@${ep_comments_page_version} >> $install_log 2>&1
 # Framapad - Displays paragraphs, sentences, words and characters counts.

--- a/scripts/install
+++ b/scripts/install
@@ -220,7 +220,7 @@ chmod 600 $final_path/credentials.json
 ynh_script_progression --message="Configuring a systemd service..." --weight=4
 
 # Create a dedicated systemd config
-ynh_add_systemd_config
+ynh_add_systemd_config --others_var="ynh_node_load_PATH"
 
 #=================================================
 # ADVERTISE SERVICE IN ADMIN PANEL

--- a/scripts/install
+++ b/scripts/install
@@ -307,6 +307,10 @@ fi
 # Etherpad admin page doesn't support SSO...
 ynh_permission_create --permission="admin" --url="/admin" --allowed=$admin
 
+if [ $mypads -eq 1 ]; then
+	ynh_permission_create --permission="admin" --url="/mypads/?/admin" --allowed=$admin
+fi
+
 #=================================================
 # RELOAD NGINX
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -308,7 +308,7 @@ fi
 ynh_permission_create --permission="admin" --url="/admin" --allowed=$admin
 
 if [ $mypads -eq 1 ]; then
-	ynh_permission_create --permission="admin" --url="/mypads/?/admin" --allowed=$admin
+	ynh_permission_create --permission="mypads_admin" --url="/mypads/?/admin" --allowed=$admin
 fi
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -302,10 +302,6 @@ fi
 # Etherpad admin page doesn't support SSO...
 ynh_permission_create --permission="admin" --url="/admin" --allowed=$admin
 
-if [ $mypads -eq 1 ]; then
-	ynh_permission_create --permission="mypads_admin" --url="/mypads/?/admin" --allowed=$admin
-fi
-
 #=================================================
 # RELOAD NGINX
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -137,7 +137,7 @@ if ! ynh_permission_exists --permission="admin"; then
   # Create the required permissions
   ynh_permission_create --permission="admin" --url="/admin" --allowed=$admin
   if [ $mypads -eq 1 ]; then
-    ynh_permission_create --permission="admin" --url="/mypads/?/admin" --allowed=$admin
+    ynh_permission_create --permission="mypads_admin" --url="/mypads/?/admin" --allowed=$admin
   fi
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -432,7 +432,7 @@ ynh_script_progression --message="Upgrading systemd configuration..." --weight=2
 # Overwrite the systemd configuration only if it's allowed
 if [ $overwrite_systemd -eq 1 ]
 then
-	ynh_add_systemd_config --others_var="ynh_node_load_PATH"
+	ynh_add_systemd_config
 fi
 
 #=================================================
@@ -441,10 +441,7 @@ fi
 
 if [ "$upgrade_type" == "UPGRADE_APP" ] && [ $mypads -eq 1 ]
 then
-	# # Find the /div just after the field to open a pad
-	# mod_line=$(grep -nA5 "index.createOpenPad" $final_path/src/templates/index.html | grep "</div>" | cut -d '-' -f 1)
-	# # In order to add a link to mypads plugin.
-	# sed -i "$mod_line s@div>@&\n\t<center><br><font size="5"><a href="./mypads/">MyPads</a></font></center>@" $final_path/src/templates/index.html
+	# Find the /div just after the field to open a pad in order to add a link to mypads plugin.
   sed -i '157i<center><br><font size="4"><a href="./mypads/" style="text-decoration: none; color: #555">MyPads</a></font></center>' $final_path/src/templates/index.html
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -291,8 +291,6 @@ pushd "$final_path"
 ynh_npm install ep_align@${ep_align_version} >> $install_log 2>&1
 # Framapad - Adds author names to span titles
 ynh_npm install ep_author_hover@${ep_author_hover_version} >> $install_log 2>&1
-# Automatically disconnects user after some period of time (Prevent server overload)
-ynh_npm install ep_automatic_logut@${ep_automatic_logut_version} >> $install_log 2>&1
 # Framapad - Adds comments on sidebar and link it to the text.
 ynh_npm install ep_comments_page@${ep_comments_page_version} >> $install_log 2>&1
 # Framapad - Displays paragraphs, sentences, words and characters counts.

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -136,6 +136,9 @@ fi
 if ! ynh_permission_exists --permission="admin"; then
   # Create the required permissions
   ynh_permission_create --permission="admin" --url="/admin" --allowed=$admin
+  if [ $mypads -eq 1 ]; then
+    ynh_permission_create --permission="admin" --url="/mypads/?/admin" --allowed=$admin
+  fi
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -432,7 +432,7 @@ ynh_script_progression --message="Upgrading systemd configuration..." --weight=2
 # Overwrite the systemd configuration only if it's allowed
 if [ $overwrite_systemd -eq 1 ]
 then
-	ynh_add_systemd_config
+	ynh_add_systemd_config --others_var="ynh_node_load_PATH"
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -136,9 +136,6 @@ fi
 if ! ynh_permission_exists --permission="admin"; then
   # Create the required permissions
   ynh_permission_create --permission="admin" --url="/admin" --allowed=$admin
-  if [ $mypads -eq 1 ]; then
-    ynh_permission_create --permission="mypads_admin" --url="/mypads/?/admin" --allowed=$admin
-  fi
 fi
 
 #=================================================


### PR DESCRIPTION
- Automatic logut plugin make etherpad crash when trying to uninstall it. This plugin asn't been upgraded seens 5 years.