### PR TITLE
Remove table of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Etherpad is a real-time collaborative editor scalable to thousands of simultaneo
 This version of Etherpad is preconfigured with a collection of plugins: 
 
 - [ep_mypads](https://www.npmjs.com/package/ep_mypads) - *Groups and private pads for etherpad*
-- [ep_table_of_contents](https://www.npmjs.com/package/ep_table_of_contents) - *Display pad's table of contents*
 - [ep_align](https://www.npmjs.com/package/ep_align) - *Add Left/Center/Right/Justify alignment*
 - [ep_author_hover](https://www.npmjs.com/package/ep_author_hover) - *Display author names when hovereing text*
 - [ep_comments_page](https://www.npmjs.com/package/ep_comments_page) - *Add comments on sidebar and link it to the text.*

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,6 @@ Etherpad est un éditeur collaboratif en temps réel évolutif pour des milliers
 Cette version d'Etherpad est préconfigurée avec une collection de plugins:
 
 - [ep_mypads](https://www.npmjs.com/package/ep_mypads) - *Groupes et pads privés pour etherpad*
-- [ep_table_of_contents](https://www.npmjs.com/package/ep_table_of_contents) - *Affichage de la table des matières*
 - [ep_align](https://www.npmjs.com/package/ep_align) - *Ajout de l'alignement à gauche/centre/droit/justifié*
 - [ep_author_hover](https://www.npmjs.com/package/ep_author_hover) - *Affichage de l'auteur lorsqu'on passe la souris au dessus d'un texte*
 - [ep_comments_page](https://www.npmjs.com/package/ep_comments_page) - *Ajout de commentaire dans la barre latéral + lien avec le texte du pad*

--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -3,7 +3,6 @@ Etherpad is a real-time collaborative editor scalable to thousands of simultaneo
 This version of Etherpad is preconfigured with a collection of plugins: 
 
 - [ep_mypads](https://www.npmjs.com/package/ep_mypads) - *Groups and private pads for etherpad*
-- [ep_table_of_contents](https://www.npmjs.com/package/ep_table_of_contents) - *Display pad's table of contents*
 - [ep_align](https://www.npmjs.com/package/ep_align) - *Add Left/Center/Right/Justify alignment*
 - [ep_author_hover](https://www.npmjs.com/package/ep_author_hover) - *Display author names when hovereing text*
 - [ep_comments_page](https://www.npmjs.com/package/ep_comments_page) - *Add comments on sidebar and link it to the text.*

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -3,7 +3,6 @@ Etherpad est un éditeur collaboratif en temps réel évolutif pour des milliers
 Cette version d'Etherpad est préconfigurée avec une collection de plugins:
 
 - [ep_mypads](https://www.npmjs.com/package/ep_mypads) - *Groupes et pads privés pour etherpad*
-- [ep_table_of_contents](https://www.npmjs.com/package/ep_table_of_contents) - *Affichage de la table des matières*
 - [ep_align](https://www.npmjs.com/package/ep_align) - *Ajout de l'alignement à gauche/centre/droit/justifié*
 - [ep_author_hover](https://www.npmjs.com/package/ep_author_hover) - *Affichage de l'auteur lorsqu'on passe la souris au dessus d'un texte*
 - [ep_comments_page](https://www.npmjs.com/package/ep_comments_page) - *Ajout de commentaire dans la barre latéral + lien avec le texte du pad*

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -22,7 +22,6 @@ ep_headings2_version=0.2.44
 ep_markdown_version=0.1.50
 ep_spellcheck_version=0.0.43
 ep_subscript_and_superscript_version=0.2.47
-ep_table_of_contents_version=0.3.42
 ep_font_size_version=0.4.44
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -148,8 +148,6 @@ pushd "$install_dir"
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_spellcheck@${ep_spellcheck_version}
 	# Framapad - Add support for Subscript and Superscript
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_subscript_and_superscript@${ep_subscript_and_superscript_version}
-	# Framapad - View a table of contents for your pad
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_table_of_contents@${ep_table_of_contents_version}
 	# Framapad - User Pad Contents font size can be set in settings, this does not effect other peoples views
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_font_size@${ep_font_size_version}
 popd

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -291,8 +291,6 @@ pushd "$install_dir"
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_spellcheck@${ep_spellcheck_version}
 	# Framapad - Add support for Subscript and Superscript
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_subscript_and_superscript@${ep_subscript_and_superscript_version}
-	# Framapad - View a table of contents for your pad
-	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_table_of_contents@${ep_table_of_contents_version}
 	# Framapad - User Pad Contents font size can be set in settings, this does not effect other peoples views
 	ynh_exec_warn_less ynh_exec_as $app env $ynh_node_load_PATH $ynh_npm install --no-save ep_font_size@${ep_font_size_version}
 popd


### PR DESCRIPTION
## Problem

cf for example Sans-nuage's pad, which are integrated in a Libretro : the table of content extension is just unecessary bloat and pollutes the UI ... Maybe for some specific case, it makes sense, but should definitely be opt-in rather than enabled everywhere

## Solution

Don't install the extension anymore
