### PR TITLE
Set client_max_body_size to 50 MB

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,6 +5,8 @@ location __PATH__/ {
   proxy_set_header   Host $host;
   proxy_pass_header  Server;
 
+  client_max_body_size 50M;
+  
   # be careful, this line doesn't override any proxy_buffering on set in a conf.d/file.conf
   proxy_buffering off;
   more_set_headers "X-Frame-Options : ALLOWALL";


### PR DESCRIPTION
## Problem

- Cannot import a pad from a file that is bigger than 1 MB. The default max import size in etherpad config is 50 MB ("importMaxFileSize": 52428800 in settings.json). But the default max body size of nginx is 1 MB only. 

## Solution

- Set max body size in nginx config to 50 MB

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
