### PR TITLE
Fix stale sha256 for the Etherpad 1.9.1 tarball

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -81,7 +81,7 @@ ram.runtime = "50M"
 
         [resources.sources.main]
         url = "https://github.com/ether/etherpad-lite/archive/1.9.1.tar.gz"
-        sha256 = "667741235a2bcd8d28a32f5e611b82fb2ea7d11525ff41b8b5478b05a987b047"
+        sha256 = "a7824901936e4ebc593df3134e94fa92514ea1c5cd75d44a0085cc23f1344dea"
         autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]


### PR DESCRIPTION
## Problem

- The app is marked **broken (level 0)** in the catalog. Every one of the 10 CI tests fails, but for a single reason: GitHub re-generated the auto-generated archive at `ether/etherpad-lite/archive/1.9.1.tar.gz`, so the pinned checksum no longer matches what is served.

  ```
  Expected   sha256: 667741235a2bcd8d28a32f5e611b82fb2ea7d11525ff41b8b5478b05a987b047
  Downloaded sha256: a7824901936e4ebc593df3134e94fa92514ea1c5cd75d44a0085cc23f1344dea
  ```

- Install aborts at `Provisioning sources` before a single script runs, so the other failures (subdir, multi, backup/restore, upgrade, change_url, the three export scenarios) are all cascade — nothing else in the package was ever exercised. See [job 37052](https://ci-apps.yunohost.org/ci/job/37052).

## Solution

- Update the pinned `sha256` to the checksum GitHub actually serves today (verified by downloading the tarball).
- **No version bump**, deliberately: the change is invisible to already-installed instances, and pushing an upgrade would needlessly re-run the 2022-era npm plugin installs on an EOL Node 14 stack. This unblocks new installs and CI only.
- This also gives #249  (the Etherpad 2.7.3 work) a `master` commit it can actually test upgrades from — `test_upgrade_from` runs a real install from the referenced commit, which is impossible while the checksum is stale.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
