### PR TITLE
Modernize etherpad 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Online editor providing collaborative editing in real-time
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](http://etherpad.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://video.etherpad.com)
-[![Version: 3.2.0~ynh1](https://img.shields.io/badge/Version-3.2.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad_mypads/)
+[![Version: 3.3.0~ynh1](https://img.shields.io/badge/Version-3.3.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad_mypads/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/etherpad_mypads"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Online editor providing collaborative editing in real-time
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](http://etherpad.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://video.etherpad.com)
-[![Version: 3.3.0~ynh1](https://img.shields.io/badge/Version-3.3.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad_mypads/)
+[![Version: 2.7.3~ynh1](https://img.shields.io/badge/Version-2.7.3~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/etherpad_mypads/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/etherpad_mypads"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>
@@ -40,6 +40,11 @@ sudo yunohost app install https://github.com/YunoHost-Apps/etherpad_mypads_ynh/t
 sudo yunohost app upgrade etherpad_mypads -u https://github.com/YunoHost-Apps/etherpad_mypads_ynh/tree/testing
 ```
 
+You can also switch to the testing branch to update from testing by default (as same as for APT when you chose to use a testing repos) with this command:
+```bash
+sudo yunohost app setting etherpad_mypads upgrade_channel -v testing
+```
+
 ### 📚 App packaging documentation
 
-Please see <https://doc.yunohost.org/packaging_apps> for more information.
+Please see <https://doc.yunohost.org/dev/packaging/> for more information.

--- a/conf/lang_mypads.sql
+++ b/conf/lang_mypads.sql
@@ -1,1 +1,7 @@
-UPDATE `store` SET `value`='"__LANGUAGE__"' WHERE `key`="mypads:conf:defaultLanguage"
+-- Set MyPads' default UI language to the one picked at install time.
+-- INSERT ... ON DUPLICATE KEY UPDATE rather than a plain UPDATE: on a fresh
+-- install MyPads has not necessarily written its config keys yet, and a bare
+-- UPDATE would silently match no row.
+INSERT INTO `store` (`key`, `value`)
+VALUES ('mypads:conf:defaultLanguage', '"__LANGUAGE__"')
+ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);

--- a/conf/settings.json
+++ b/conf/settings.json
@@ -422,15 +422,6 @@
   },
 
   // Other plugins config
-  // ep_comments_page
-    // Display comments as icons, not boxes
-    "ep_comments_page": {
-      "displayCommentAsIcon": false
-    },
-    // Highlight selected text when adding comment
-    "ep_comments_page": {
-      "highlightSelectedText": false
-    },
     // ep_mypads
 __COMMENT_IF_LDAP_DISABLED__    "ep_mypads": {
 __COMMENT_IF_LDAP_DISABLED__      "ldap": {

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Etherpad MyPads"
 description.en = "Online editor providing collaborative editing in real-time"
 description.fr = "Éditeur en ligne fournissant l'édition collaborative en temps réel"
 
-version = "3.3.0~ynh1"
+version = "2.7.3~ynh1"
 
 maintainers = []
 
@@ -25,7 +25,7 @@ multi_instance = true
 ldap = true
 sso = false
 
-disk = "200M"
+disk = "1500M"
 ram.build = "1500M"
 ram.runtime = "50M"
 
@@ -76,9 +76,14 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/3.3.0.tar.gz"
-    sha256 = "116f43e60e9cf74004a98405cfd5e02a1da6ad26130fde7c4a476cdc575a8551"
+    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/2.7.3.tar.gz"
+    sha256 = "0c00483ccec888678579b58004ecd6d698ab61c69532ba3a3a1252515fa652cc"
     autoupdate.strategy = "latest_github_tag"
+    # Stay on the Etherpad 2.x line: ep_mypads explicitly refuses to install on
+    # Etherpad 3 (upstream commit "Prevent installing on Etherpad 3") and declares
+    # peerDependencies { "ep_etherpad-lite": "^2.5.0" }. Drop this once MyPads
+    # ships a release supporting Etherpad 3.
+    autoupdate.version_regex = '^v?(2\.\d+\.\d+)$'
 
     [resources.system_user]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Etherpad MyPads"
 description.en = "Online editor providing collaborative editing in real-time"
 description.fr = "Éditeur en ligne fournissant l'édition collaborative en temps réel"
 
-version = "3.2.0~ynh1"
+version = "3.3.0~ynh1"
 
 maintainers = []
 
@@ -76,8 +76,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/3.2.0.tar.gz"
-    sha256 = "eb89c7be586d5793f5ba74eb1e891c2992a883b732872d74c14d55d556b0e932"
+    url = "https://github.com/ether/etherpad-lite/archive/refs/tags/3.3.0.tar.gz"
+    sha256 = "116f43e60e9cf74004a98405cfd5e02a1da6ad26130fde7c4a476cdc575a8551"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -48,7 +48,7 @@ ram.runtime = "50M"
     ask.fr = "Choisissez la langue"
     type = "select"
     choices = ["ca", "de", "en", "es", "fr", "gl", "hu", "it", "nl", "pt"]
-    default = "fr"
+    default = "en"
 
     [install.admin]
     type = "user"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,6 +8,11 @@
 # This variable is mostly used to force an upgrade of the package in case of new versions of MyPads.
 mypads_version=2.0.1
 
+# pnpm version -> must track the "packageManager" field of Etherpad's own
+# package.json, so corepack installs what upstream tested against rather than
+# whatever "pnpm@latest" happens to be that day.
+pnpm_version=11.0.6
+
 # Plugin versions -> https://static.etherpad.org/index.html
 ep_align_version=11.0.43
 ep_author_hover_version=11.0.34

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 # MyPads version
 # This variable is mostly used to force an upgrade of the package in case of new versions of MyPads.
-mypads_version=1.7.25
+mypads_version=2.0.1
 
 # Plugin versions -> https://static.etherpad.org/index.html
 ep_align_version=11.0.29

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -21,7 +21,7 @@ ynh_config_change_url_nginx
 #=================================================
 ynh_script_progression "Starting $app's systemd service..."
 
-ynh_systemctl --service="$app" --action=restart --log_path=systemd --wait_until="Etherpad is running"
+ynh_systemctl --service="$app" --action=restart --log_path=systemd --wait_until="Etherpad is running" --timeout=120
 
 #=================================================
 # DEACTIVE MAINTENANCE MODE

--- a/scripts/install
+++ b/scripts/install
@@ -51,7 +51,7 @@ ynh_config_add --template="settings.json" --destination="$install_dir/settings.j
 ynh_script_progression "Installing $app and plugins..."
 
 pushd "$install_dir"
-	ynh_hide_warnings corepack enable && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack prepare pnpm@latest --activate
+	ynh_hide_warnings corepack enable && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack prepare pnpm@${pnpm_version} --activate
     ynh_hide_warnings ynh_exec_as_app pnpm install
     ynh_hide_warnings ynh_exec_as_app pnpm run build:etherpad
     chown -R $app:$app ./node_modules
@@ -70,20 +70,27 @@ popd
 # SOME HACKS
 #=================================================
 
-#if [ $mypads -eq 1 ]
-#then
-#    ynh_script_progression "Tweaking MyPad configuration..."
-#
-#	# Add a link to Etherpad to allow anonymous pads creation from MyPads.
-#	ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Pads anonymes</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/fr.json
-#	ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Anonymous pads</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/en.json
-	# And a link to Etherpad admin from MyPads.
-#	ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/en.json
-#	ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/fr.json
+if [ $mypads -eq 1 ]
+then
+    ynh_script_progression "Tweaking MyPads configuration..."
 
-    # Find the /div just after the field to open a pad in order to add a link to MyPads plugin.
-#   sed -i '157i<center><br><font size="4"><a href="./mypads/" style="text-decoration: none; color: #555">MyPads</a></font></center>' $install_dir/src/templates/index.html
-#fi
+    # Etherpad 2.x installs plugins into src/plugin_packages/ and symlinks them
+    # into src/node_modules/ (see src/static/js/pluginfw/installer.ts).
+    mypads_dir="$install_dir/src/plugin_packages/ep_mypads"
+    [ -d "$mypads_dir" ] || ynh_die "MyPads was requested but $mypads_dir does not exist after the plugin install — did Etherpad change where it unpacks plugins?"
+
+    # Add a link to Etherpad to allow anonymous pads creation from MyPads.
+    ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Pads anonymes</a>" --file="$mypads_dir/static/l10n/fr.json"
+    ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Anonymous pads</a>" --file="$mypads_dir/static/l10n/en.json"
+    # And a link to Etherpad admin from MyPads.
+    ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file="$mypads_dir/static/l10n/en.json"
+    ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file="$mypads_dir/static/l10n/fr.json"
+
+    # Add a link to MyPads just below the "open a pad" form of the index page.
+    # Anchored on </form>, which is unique in that template, rather than on a
+    # hardcoded line number.
+    ynh_replace --match="^\( *\)</form>" --replace="&\n\1<center><br><font size=\"4\"><a href=\"./mypads/\" style=\"text-decoration: none; color: #555\">MyPads</a></font></center>" --file="$install_dir/src/templates/index.html"
+fi
 
 #=================================================
 # SYSTEM CONFIGURATION
@@ -105,15 +112,19 @@ ynh_config_add_fail2ban --logpath="/var/log/nginx/$domain-access.log" --failrege
 #=================================================
 ynh_script_progression "Starting systemd service..."
 
-ynh_systemctl --service="$app" --action=restart
+# Wait for Etherpad to be fully up: it creates the ueberDB `store` table during
+# startup, and the MyPads language query below reads it.
+ynh_systemctl --service="$app" --action=restart --log_path=systemd --wait_until="Etherpad is running" --timeout=120
 
-#if [ $mypads -eq 1 ]
-#then
-#    ynh_replace --match="__LANGUAGE__" --replace="$language" --file="../conf/lang_mypads.sql"
-#    ynh_mysql_db_shell < "../conf/lang_mypads.sql"
+if [ $mypads -eq 1 ]
+then
+    ynh_script_progression "Setting MyPads default language..."
 
-#    ynh_systemctl --service="$app" --action=restart
-#fi
+    ynh_replace --match="__LANGUAGE__" --replace="$language" --file="../conf/lang_mypads.sql"
+    ynh_mysql_db_shell < "../conf/lang_mypads.sql"
+
+    ynh_systemctl --service="$app" --action=restart --log_path=systemd --wait_until="Etherpad is running" --timeout=120
+fi
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -107,13 +107,13 @@ ynh_script_progression "Starting systemd service..."
 
 ynh_systemctl --service="$app" --action=restart
 
-if [ $mypads -eq 1 ]
-then
-    ynh_replace --match="__LANGUAGE__" --replace="$language" --file="../conf/lang_mypads.sql"
-    ynh_mysql_db_shell < "../conf/lang_mypads.sql"
+#if [ $mypads -eq 1 ]
+#then
+#    ynh_replace --match="__LANGUAGE__" --replace="$language" --file="../conf/lang_mypads.sql"
+#    ynh_mysql_db_shell < "../conf/lang_mypads.sql"
 
-    ynh_systemctl --service="$app" --action=restart
-fi
+#    ynh_systemctl --service="$app" --action=restart
+#fi
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/restore
+++ b/scripts/restore
@@ -49,7 +49,10 @@ ynh_systemctl --action=restart --service=fail2ban
 #=================================================
 ynh_script_progression "Restoring the MySQL database..."
 
-echo "ALTER DATABASE $db_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" | ynh_mysql_db_shell < ./db.sql
+# Two separate calls: piping the ALTER while also redirecting db.sql onto stdin
+# silently discarded the ALTER, since the redirection wins over the pipe.
+ynh_mysql_db_shell <<< "ALTER DATABASE \`$db_name\` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
+ynh_mysql_db_shell < ./db.sql
 
 #=================================================
 # RELOAD NGINX AND PHP-FPM OR THE APP SERVICE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -22,7 +22,7 @@ ynh_systemctl --service=$app --action="stop"
 #=================================================
 ynh_script_progression "Ensuring downward compatibility..."
 
-ynh_app_setting_set_default --key=anguage --value=en
+ynh_app_setting_set_default --key=language --value=en
 ynh_app_setting_set_default --key=mypads --value=1
 ynh_app_setting_set_default --key=useldap --value=0
 ynh_app_setting_set_default --key=path --value="/"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -26,9 +26,14 @@ ynh_app_setting_set_default --key=language --value=en
 ynh_app_setting_set_default --key=mypads --value=1
 ynh_app_setting_set_default --key=useldap --value=0
 ynh_app_setting_set_default --key=path --value="/"
-ynh_app_setting_set_default --key=password --value=$(ynh_string_random --length=32)
+ynh_app_setting_set_default --key=password --value="$(ynh_string_random --length=32)"
 
-#ynh_mysql_db_shell <<< "ALTER DATABASE $db_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
+# The "export" question is gone: Etherpad 2.x talks to soffice directly and
+# libreoffice-writer is now a plain apt dependency, so AbiWord/unoconv and the
+# setting that selected them are obsolete. (The apt resource drops the packages
+# themselves; the nodejs resource garbage-collects the node 14 that the old
+# ynh_install_nodejs helper had put under /opt/node_n.)
+ynh_app_setting_delete --key=export
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
@@ -58,7 +63,7 @@ ynh_config_add --template="settings.json" --destination="$install_dir/settings.j
 ynh_script_progression "Upgrading $app..."
 
 pushd "$install_dir"
-    ynh_hide_warnings corepack enable && corepack prepare pnpm@latest --activate
+    ynh_hide_warnings corepack enable && COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack prepare pnpm@${pnpm_version} --activate
     ynh_hide_warnings ynh_exec_as_app pnpm install
     ynh_hide_warnings ynh_exec_as_app pnpm run build:etherpad
     ynh_hide_warnings ynh_exec_as_app pnpm run plugins install ep_align@${ep_align_version} \
@@ -77,17 +82,25 @@ popd
 
 if [ $mypads -eq 1 ]
 then
-	ynh_script_progression --message="Tweaking MyPads configuration..."
+    ynh_script_progression "Tweaking MyPads configuration..."
 
-	# Add a link to Etherpad to allow anonymous pads creation from MyPads.
-	ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Pads anonymes</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/fr.json
-	ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Anonymous pads</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/en.json
-	# And a link to Etherpad admin from MyPads.
-	ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/en.json
-	ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file=$install_dir/node_modules/ep_etherpad-lite/plugin_packages/ep_mypads/static/l10n/fr.json
+    # Etherpad 2.x installs plugins into src/plugin_packages/ and symlinks them
+    # into src/node_modules/ (see src/static/js/pluginfw/installer.ts).
+    mypads_dir="$install_dir/src/plugin_packages/ep_mypads"
+    [ -d "$mypads_dir" ] || ynh_die "MyPads was requested but $mypads_dir does not exist after the plugin install — did Etherpad change where it unpacks plugins?"
 
-	# Find the /div just after the field to open a pad in order to add a link to MyPads plugin.
-	sed -i '157i<center><br><font size="4"><a href="./mypads/" style="text-decoration: none; color: #555">MyPads</a></font></center>' $install_dir/src/templates/index.html
+    # Add a link to Etherpad to allow anonymous pads creation from MyPads.
+    ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Pads anonymes</a>" --file="$mypads_dir/static/l10n/fr.json"
+    ynh_replace --match="^ *\"DESCRIPTION\": .*</ul>" --replace="&<a href=../>Anonymous pads</a>" --file="$mypads_dir/static/l10n/en.json"
+    # And a link to Etherpad admin from MyPads.
+    ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file="$mypads_dir/static/l10n/en.json"
+    ynh_replace --match="^ *\"FOOTER\": .*2.0" --replace="& | <a href='../admin'>Etherpad admin</a>" --file="$mypads_dir/static/l10n/fr.json"
+
+    # Add a link to MyPads just below the "open a pad" form of the index page.
+    # Anchored on </form>, which is unique in that template, rather than on a
+    # hardcoded line number. Safe to run unguarded because ynh_setup_source
+    # --full_replace above reinstates a pristine template on every upgrade.
+    ynh_replace --match="^\( *\)</form>" --replace="&\n\1<center><br><font size=\"4\"><a href=\"./mypads/\" style=\"text-decoration: none; color: #555\">MyPads</a></font></center>" --file="$install_dir/src/templates/index.html"
 fi
 
 #=================================================
@@ -110,7 +123,19 @@ ynh_config_add_fail2ban --logpath="/var/log/nginx/$domain-access.log" --failrege
 #=================================================
 ynh_script_progression "Starting systemd service..."
 
-ynh_systemctl --service="$app" --action=restart
+# Wait for Etherpad to be fully up: it creates the ueberDB `store` table during
+# startup, and the MyPads language query below reads it.
+ynh_systemctl --service="$app" --action=restart --log_path=systemd --wait_until="Etherpad is running" --timeout=120
+
+if [ $mypads -eq 1 ]
+then
+    ynh_script_progression "Setting MyPads default language..."
+
+    ynh_replace --match="__LANGUAGE__" --replace="$language" --file="../conf/lang_mypads.sql"
+    ynh_mysql_db_shell < "../conf/lang_mypads.sql"
+
+    ynh_systemctl --service="$app" --action=restart --log_path=systemd --wait_until="Etherpad is running" --timeout=120
+fi
 
 #=================================================
 # DEACTIVE MAINTENANCE MODE

--- a/tests.toml
+++ b/tests.toml
@@ -16,6 +16,10 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
+    # Etherpad 1.9.1 on helpers 2.0 — what every currently-installed instance
+    # runs, so this is the migration that actually matters.
+    test_upgrade_from.033df98.name = "1.9.1~ynh3"
+
 [with_MyPads]
     args.mypads = 1
     args.useldap = 1


### PR DESCRIPTION
## Problem

Two separate things were blocking this app.

**1. `master` is broken.** A stale source checksum makes every install fail before any script runs (fixed separately in #TODO).

**2. The modernization on `testing` / #247 targeted Etherpad 3.3.3, where MyPads cannot work.** `ep_mypads@2.0.1` declares `peerDependencies { "ep_etherpad-lite": "^2.5.0" }`, because upstream added a commit literally titled [`📌 — Prevent installing on Etherpad 3`](https://framagit.org/framasoft/ep_mypads) (2026-05-18). Since MyPads is the reason this package exists separately from `etherpad_ynh`, targeting 3.x is a dead end until upstream ships a 3.x-compatible release.

**3. The `with_MyPads` CI failure on #247 was misdiagnosed.** [Job 23202](https://ci-apps-dev.yunohost.org/ci/job/23202) shows `systemctl restart` followed 0.3 s later by `lang_mypads.sql`, failing with `ERROR 1146 — Table 'etherpad_mypads.store' doesn't exist`. That is a race, not a MyPads problem — Etherpad simply had not finished creating the ueberDB table yet. The response on #247 was to comment the language step out, which hides the symptom rather than fixing it.

## Solution

**Retarget to Etherpad 2.7.3** — the newest release MyPads supports:

- `sha256 = 0c00483ccec888678579b58004ecd6d698ab61c69532ba3a3a1252515fa652cc` (the `2.7.3` and `v2.7.3` tags produce an identical tarball).
- Pin the autoupdater to the 2.x line with `autoupdate.version_regex = '^v?(2\.\d+\.\d+)$'`, so the bot cannot walk us back onto 3.x. Commented with the reason, to be dropped once MyPads supports Etherpad 3.
- Etherpad 2.7.3 requires `node >= 22.13.0`, so the existing `[resources.nodejs] version = "24"` still applies.

**Fix the MyPads install race properly:**

- Wait for `"Etherpad is running"` on the journal instead of restarting blind. `db.init()` runs before that line is logged (`src/node/server.ts:154-175`), so the `store` table is guaranteed to exist afterwards.
- Re-enable the language step that had been commented out, and make `lang_mypads.sql` an `INSERT ... ON DUPLICATE KEY UPDATE` — the previous bare `UPDATE` silently matched no row when MyPads had yet to write its config keys.

**Fix the MyPads tweaks, which pointed at a directory that does not exist:**

- They targeted `node_modules/ep_etherpad-lite/plugin_packages/`, but Etherpad 2.x unpacks plugins into `src/plugin_packages/` and symlinks them into `src/node_modules/` (`src/static/js/pluginfw/installer.ts:24`). Corrected, and guarded with an explicit `ynh_die` so a future layout change fails legibly instead of as a confusing `sed` error.
- Replaced the `sed -i '157i…'` line-number hack with an anchor on `</form>`, which is unique in that template.

**Other fixes found along the way:**

- `scripts/restore`: `echo "ALTER DATABASE …" | ynh_mysql_db_shell < ./db.sql` silently discarded the `ALTER`, since the stdin redirection wins over the pipe. Split into two calls.
- `conf/settings.json`: dropped the `ep_comments_page` config — a duplicate JSON key, for a plugin that is no longer installed.
- `scripts/upgrade`: delete the obsolete `export` setting from 1.9.x instances (AbiWord/unoconv are gone; `soffice` is hardcoded and `libreoffice-writer` is a plain apt dependency).
- Pin pnpm to Etherpad's own `packageManager` version (`11.0.6`, tracked in `_common.sh`) instead of `pnpm@latest`.
- `disk = "200M"` did not cover the 1264 MB the MyPads install actually uses; raised to `1500M`.
- `tests.toml`: added `test_upgrade_from` for `1.9.1~ynh3` — the version every installed instance is actually running, and the migration that matters. **This requires #248  to be merged first**, since package_check performs a real install from the referenced commit.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

Verified locally: package linter is clean and qualifies for level 7 (the three warnings on `master` are gone); all scripts pass `bash -n`; both TOML files parse; the autoupdate regex accepts 2.x and filters 3.x; `settings.json` renders as valid JSON with LDAP both enabled and disabled; the four `sed` replacements were dry-run against the real Etherpad 2.7.3 template and the real `ep_mypads@2.0.1` l10n files and produce valid JSON.

Not yet verified, and worth attention in review:

- **`ep_mypads@2.0.1` on Etherpad 2.7.3 has not been run** — only the peer range says it fits. The `with_MyPads` CI scenario should confirm it, and `/mypads/` should be opened by hand.
- **Node 24 with Etherpad 2.7.3** — `engines` allows it (`>= 22.13.0`), but the only CI evidence for node 24 is against 3.3.3. Fallback would be `[resources.nodejs] version = "22"`.
- **The 1.9.1 → 2.7.3 upgrade** is a two-major jump for ueberDB and MyPads data. Beyond the CI test, this deserves a manual run on an instance holding real pads *and* MyPads groups.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
